### PR TITLE
fix: gw2_floors > gw2_map_floors

### DIFF
--- a/inc/config.inc.php
+++ b/inc/config.inc.php
@@ -20,6 +20,6 @@ define('TABLE_EVENTS', 'gw2_events');
 define('TABLE_MAPS', 'gw2_maps');
 define('TABLE_RECIPES', 'gw2_recipes');
 define('TABLE_SKINS', 'gw2_skins');
-define('TABLE_FLOORS', 'gw2_floors');
+define('TABLE_FLOORS', 'gw2_map_floors');
 define('TABLE_REGIONS', 'gw2_regions');
 define('TABLE_DIFF', 'gw2_diff');


### PR DESCRIPTION
[gw2_floors.sql](https://github.com/BryghtShadow/gw2-database/blob/df70e631e6e0ca7e0a17ccb74ab2062c3cd275c7/sql/gw2_floors.sql) expects the map floor table to be named `gw2_map_floors`.
